### PR TITLE
Add phpunit.xml.dist, Ignore phpunit output, Fix phpunit scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /composer.lock
 /vendor/
 /bin/
+/tests/_output/
 .phpunit.result.cache
 *~
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "psr-4": {"KintoneQueryBuilder\\" : "src/"}
     },
     "scripts": {
-        "test": "phpunit tests/*.php",
+        "test": "phpunit",
+        "coverage": "phpunit --coverage-text --coverage-html tests/_output",
         "format": "prettier --write src/*.php tests/*.php"
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/|version|/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
### Add phpunit.xml.dist

テストの実行のために `phpunit.xml.dist` を追加しました。

### Ignore phpunit output

phpunit の出力結果を保存するディレクトリを ignore しました。

### Fix phpunit scripts

`composer.json` に設定している phpunit の script の修正と coverage 用の script を追加しました。
