### PR TITLE
Refactor

### DIFF
--- a/src/KintoneQueryBuffer.php
+++ b/src/KintoneQueryBuffer.php
@@ -7,8 +7,7 @@ namespace KintoneQueryBuilder;
  * Class KintoneQueryBuffer
  * @package KintoneQueryBuilder
  */
-
-class KintoneQueryBuffer
+class KintoneQueryBuffer implements KintoneQueryBufferInterface
 {
     /**
      * null or 'and' or 'or'
@@ -17,7 +16,7 @@ class KintoneQueryBuffer
     public $conj;
 
     /**
-     * @var (KintoneQueryBuffer|KintoneQueryBuilder)[]
+     * @var KintoneQueryBufferInterface[]
      */
     public $buffer;
 
@@ -32,9 +31,9 @@ class KintoneQueryBuffer
     }
 
     /**
-     * @param KintoneQueryBuffer|KintoneQueryBufferElement $obj
+     * @param KintoneQueryBufferInterface $obj
      */
-    public function append($obj): void
+    public function append(KintoneQueryBufferInterface $obj): void
     {
         $this->buffer[] = $obj;
     }

--- a/src/KintoneQueryBuffer.php
+++ b/src/KintoneQueryBuffer.php
@@ -13,12 +13,12 @@ class KintoneQueryBuffer implements KintoneQueryBufferInterface
      * null or 'and' or 'or'
      * @var string|null
      */
-    public $conj;
+    private $conj;
 
     /**
      * @var KintoneQueryBufferInterface[]
      */
-    public $buffer;
+    private $buffer;
 
     /**
      * KintoneQueryBuffer constructor.
@@ -28,6 +28,33 @@ class KintoneQueryBuffer implements KintoneQueryBufferInterface
     {
         $this->buffer = [];
         $this->conj = $conj;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getConj(): ?string
+    {
+        return $this->conj;
+    }
+
+    /**
+     * @param string|null $conj
+     * @return self
+     */
+    public function setConj(?string $conj): self
+    {
+        $this->conj = $conj;
+
+        return $this;
+    }
+
+    /**
+     * @return KintoneQueryBufferInterface[]
+     */
+    public function getBuffer(): array
+    {
+        return $this->buffer;
     }
 
     /**
@@ -62,7 +89,7 @@ class KintoneQueryBuffer implements KintoneQueryBufferInterface
             if ($i == 0) {
                 $query .= $subQuery;
             } else {
-                $query .= ' ' . $e->conj . ' ' . $subQuery;
+                $query .= ' ' . $e->getConj() . ' ' . $subQuery;
             }
         }
         if ($query === '') {

--- a/src/KintoneQueryBuffer.php
+++ b/src/KintoneQueryBuffer.php
@@ -86,7 +86,7 @@ class KintoneQueryBuffer implements KintoneQueryBufferInterface
             if ($subQuery === '()' || $subQuery === '') {
                 continue;
             }
-            if ($i == 0) {
+            if ($i === 0) {
                 $query .= $subQuery;
             } else {
                 $query .= ' ' . $e->getConj() . ' ' . $subQuery;

--- a/src/KintoneQueryBuffer.php
+++ b/src/KintoneQueryBuffer.php
@@ -25,7 +25,7 @@ class KintoneQueryBuffer
      * KintoneQueryBuffer constructor.
      * @param string|null $conj
      */
-    public function __construct(string $conj = null)
+    public function __construct(?string $conj = null)
     {
         $this->buffer = [];
         $this->conj = $conj;

--- a/src/KintoneQueryBuffer.php
+++ b/src/KintoneQueryBuffer.php
@@ -40,7 +40,7 @@ class KintoneQueryBuffer implements KintoneQueryBufferInterface
 
     /**
      * @param string|null $conj
-     * @return self
+     * @return $this
      */
     public function setConj(?string $conj): self
     {

--- a/src/KintoneQueryBufferElement.php
+++ b/src/KintoneQueryBufferElement.php
@@ -6,8 +6,7 @@ namespace KintoneQueryBuilder;
  * Class KintoneQueryBufferElement
  * @package KintoneQueryBuilder
  */
-
-class KintoneQueryBufferElement
+class KintoneQueryBufferElement implements KintoneQueryBufferInterface
 {
     /**
      * null or 'and' or 'or'

--- a/src/KintoneQueryBufferElement.php
+++ b/src/KintoneQueryBufferElement.php
@@ -26,7 +26,7 @@ class KintoneQueryBufferElement
      * @param string $data
      * @param string|null $conj
      */
-    public function __construct(string $data, string $conj = null)
+    public function __construct(string $data, ?string $conj = null)
     {
         $this->data = $data;
         $this->conj = $conj;

--- a/src/KintoneQueryBufferElement.php
+++ b/src/KintoneQueryBufferElement.php
@@ -12,13 +12,13 @@ class KintoneQueryBufferElement implements KintoneQueryBufferInterface
      * null or 'and' or 'or'
      * @var string|null
      */
-    public $conj;
+    private $conj;
 
     /**
      * minimum element ('x < 10' or 'y = 10' or 'name like "banana"')
      * @var string
      */
-    public $data;
+    private $data;
 
     /**
      * KintoneQueryBufferElement constructor.
@@ -29,6 +29,14 @@ class KintoneQueryBufferElement implements KintoneQueryBufferInterface
     {
         $this->data = $data;
         $this->conj = $conj;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getConj(): ?string
+    {
+        return $this->conj;
     }
 
     /**

--- a/src/KintoneQueryBufferInterface.php
+++ b/src/KintoneQueryBufferInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace KintoneQueryBuilder;
+
+/**
+ * @author ochi51 <ochiai07@gmail.com>
+ */
+interface KintoneQueryBufferInterface
+{
+    /**
+     * @return string|null
+     */
+    public function getConj(): ?string;
+
+    /**
+     * @param bool $hasParen
+     * @return string
+     */
+    public function toQuery(bool $hasParen = false): string;
+}

--- a/src/KintoneQueryBuilder.php
+++ b/src/KintoneQueryBuilder.php
@@ -29,7 +29,7 @@ class KintoneQueryBuilder extends KintoneQueryExpr
     /**
      * @param string $var
      * @param string $ord
-     * @return self
+     * @return $this
      */
     public function orderBy(string $var, string $ord): self
     {
@@ -43,7 +43,7 @@ class KintoneQueryBuilder extends KintoneQueryExpr
 
     /**
      * @param int $n
-     * @return self
+     * @return $this
      */
     public function limit(int $n): self
     {
@@ -53,7 +53,7 @@ class KintoneQueryBuilder extends KintoneQueryExpr
 
     /**
      * @param int $n
-     * @return self
+     * @return $this
      */
     public function offset(int $n): self
     {

--- a/src/KintoneQueryBuilder.php
+++ b/src/KintoneQueryBuilder.php
@@ -29,9 +29,9 @@ class KintoneQueryBuilder extends KintoneQueryExpr
     /**
      * @param string $var
      * @param string $ord
-     * @return $this
+     * @return self
      */
-    public function orderBy(string $var, string $ord)
+    public function orderBy(string $var, string $ord): self
     {
         if ($this->orderClause === '') {
             $this->orderClause = 'order by ' . $var . ' ' . $ord;
@@ -43,9 +43,9 @@ class KintoneQueryBuilder extends KintoneQueryExpr
 
     /**
      * @param int $n
-     * @return $this
+     * @return self
      */
-    public function limit(int $n)
+    public function limit(int $n): self
     {
         $this->limitClause = 'limit ' . $n;
         return $this;
@@ -53,9 +53,9 @@ class KintoneQueryBuilder extends KintoneQueryExpr
 
     /**
      * @param int $n
-     * @return $this
+     * @return self
      */
-    public function offset(int $n)
+    public function offset(int $n): self
     {
         $this->offsetClause = 'offset ' . $n;
         return $this;

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -145,7 +145,7 @@ class KintoneQueryExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
      * @param string $conj
-     * @return self
+     * @return $this
      * @throws KintoneQueryException
      */
     private function whereWithVarOpVal(
@@ -166,7 +166,7 @@ class KintoneQueryExpr
     /**
      * @param KintoneQueryExpr $expr
      * @param string $conj
-     * @return self
+     * @return $this
      * @throws KintoneQueryException
      */
     private function whereWithExpr(KintoneQueryExpr $expr, string $conj): self
@@ -183,7 +183,7 @@ class KintoneQueryExpr
      * @param string|KintoneQueryExpr $varOrExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
-     * @return self
+     * @return $this
      * @throws KintoneQueryException
      */
     public function where($varOrExpr, string $op = '', $val = null): self
@@ -195,7 +195,7 @@ class KintoneQueryExpr
      * @param string|KintoneQueryExpr $varOrExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
-     * @return self
+     * @return $this
      * @throws KintoneQueryException
      */
     public function andWhere($varOrExpr, string $op = '', $val = null): self
@@ -218,7 +218,7 @@ class KintoneQueryExpr
      * @param string|KintoneQueryExpr $varOrExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
-     * @return self
+     * @return $this
      * @throws KintoneQueryException
      */
     public function orWhere($varOrExpr, string $op = '', $val = null): self

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -200,7 +200,7 @@ class KintoneQueryExpr
      */
     public function andWhere($varOrExpr, string $op = '', $val = null): self
     {
-        if ($varOrExpr instanceof KintoneQueryExpr) {
+        if ($varOrExpr instanceof self) {
             return $this->whereWithExpr($varOrExpr, 'and');
         }
         if (\is_string($varOrExpr)) {
@@ -223,7 +223,7 @@ class KintoneQueryExpr
      */
     public function orWhere($varOrExpr, string $op = '', $val = null): self
     {
-        if ($varOrExpr instanceof KintoneQueryExpr) {
+        if ($varOrExpr instanceof self) {
             return $this->whereWithExpr($varOrExpr, 'or');
         }
         if (\is_string($varOrExpr)) {

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -8,7 +8,7 @@ namespace KintoneQueryBuilder;
  * This class builds logical condition clauses.
  * Note that you can't specify 'offset' or 'order by' with this class.
  * In that case, you should use KintoneQueryBuilder.
- * KintoneQueryExpr can be a argment of new KintoneQueryBuilder() to build  a nested query like '(A and B) or (C and D)'.
+ * KintoneQueryExpr can be a argument of new KintoneQueryBuilder() to build  a nested query like '(A and B) or (C and D)'.
  *
  * @package KintoneQueryBuilder
  *

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -125,7 +125,7 @@ class KintoneQueryExpr
      * @return string
      * @throws KintoneQueryException
      */
-    public static function genWhereClause($var, $op, $val)
+    public static function genWhereClause($var, $op, $val): string
     {
         // case $op = 'in' or 'not in'
         if ($op === 'in' || $op === 'not in') {

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -103,7 +103,7 @@ class KintoneQueryExpr
             return '"' . self::escapeDoubleQuote($val) . '"';
         }
         if (is_int($val)) {
-            return strval($val);
+            return (string)$val;
         }
         if (is_array($val)) {
             $list = [];

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -174,7 +174,7 @@ class KintoneQueryExpr
         if ($expr->buffer->isEmpty()) {
             return $this;
         }
-        $expr->buffer->conj = $conj;
+        $expr->buffer->setConj($conj);
         $this->buffer->append($expr->buffer);
         return $this;
     }

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -145,7 +145,7 @@ class KintoneQueryExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
      * @param string $conj
-     * @return $this
+     * @return self
      * @throws KintoneQueryException
      */
     private function whereWithVarOpVal(
@@ -153,7 +153,7 @@ class KintoneQueryExpr
         string $op,
         $val,
         string $conj
-    ) {
+    ): self {
         $this->buffer->append(
             new KintoneQueryBufferElement(
                 self::genWhereClause($var, $op, $val),
@@ -166,10 +166,10 @@ class KintoneQueryExpr
     /**
      * @param KintoneQueryExpr $expr
      * @param string $conj
-     * @return $this
+     * @return self
      * @throws KintoneQueryException
      */
-    private function whereWithExpr(KintoneQueryExpr $expr, string $conj)
+    private function whereWithExpr(KintoneQueryExpr $expr, string $conj): self
     {
         if ($expr->buffer->isEmpty()) {
             return $this;
@@ -183,10 +183,10 @@ class KintoneQueryExpr
      * @param string|KintoneQueryExpr $varOrExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
-     * @return $this
+     * @return self
      * @throws KintoneQueryException
      */
-    public function where($varOrExpr, string $op = '', $val = null)
+    public function where($varOrExpr, string $op = '', $val = null): self
     {
         return $this->andWhere($varOrExpr, $op, $val);
     }
@@ -195,10 +195,10 @@ class KintoneQueryExpr
      * @param string|KintoneQueryExpr $varOrExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
-     * @return $this
+     * @return self
      * @throws KintoneQueryException
      */
-    public function andWhere($varOrExpr, string $op = '', $val = null)
+    public function andWhere($varOrExpr, string $op = '', $val = null): self
     {
         if ($varOrExpr instanceof KintoneQueryExpr) {
             return $this->whereWithExpr($varOrExpr, 'and');
@@ -218,10 +218,10 @@ class KintoneQueryExpr
      * @param string|KintoneQueryExpr $varOrExpr
      * @param string $op
      * @param int|string|(int|string)[] $val
-     * @return $this
+     * @return self
      * @throws KintoneQueryException
      */
-    public function orWhere($varOrExpr, string $op = '', $val = null)
+    public function orWhere($varOrExpr, string $op = '', $val = null): self
     {
         if ($varOrExpr instanceof KintoneQueryExpr) {
             return $this->whereWithExpr($varOrExpr, 'or');

--- a/src/KintoneQueryExpr.php
+++ b/src/KintoneQueryExpr.php
@@ -121,7 +121,7 @@ class KintoneQueryExpr
     /**
      * @param string $var
      * @param string $op
-     * @param string $val
+     * @param int|string|(int|string)[] $val
      * @return string
      * @throws KintoneQueryException
      */


### PR DESCRIPTION
### typo

`argment` -> `argument`

### Cast string is faster than strval

`(string)$val` の方が `strval($val)` より高速に同じ結果が得られます。

### return type

指定できるのに指定されていなかった return type を指定しました。

### Nullable type

Null を許可しているので、 `?` を指定しました。

### Fix param type

`genWhereClause` の `$val` の type を `valToString` に合わせました。

### Fixes own class check

`$varOrExpr instanceof KintoneQueryExpr` が自分自身を指しているので、そういう場合は、 `self` を使うのが一般的です。

### Add KintoneQueryBufferInterface

`KintoneQueryBuffer` と `KintoneQueryBufferElement` が同じ構造を持つこと前提のコードがあったので、Interface で縛りました。

### Change public property to private property

public なプロパティは特別な理由がない限り使わない方がいいです。
今回は `string|null` を前提にしていますが、public だとなんでも入れれるため、危険です。
状態の変更を行いたい場合は、Setter を作るのがベターかと思います。
（できるならSetterもなく、状態が変更されない設計の方が、安全でテストもしやすいです）

### Strict check

`==` ではなく `===` を使うようにした方がよいでしょう。