### PR TITLE
Update/readme ci badge and installation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # kintone query builder
 
-[![CircleCI](https://circleci.com/gh/toyokumo/kintone-query-builder-php.svg?style=svg)](https://circleci.com/gh/toyokumo/kintone-query-builder-php)
+[![Build and Test](https://github.com/toyokumo/kintone-query-builder-php/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/toyokumo/kintone-query-builder-php/actions/workflows/build-and-test.yml)
 
 [![PHP Version](https://img.shields.io/badge/php-7.2-pink.svg?style=flat-square)]()
 [![Latest Stable Version](https://poser.pugx.org/toyokumo/kintone-query-builder/v/stable)](https://packagist.org/packages/toyokumo/kintone-query-builder)

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,8 +11,7 @@
 ## usage
 ### インストール
 ```
-composer require toyokumo/kintone-query-builder:v1.0.0
-composer install
+composer require toyokumo/kintone-query-builder
 ```
 ### 基本的な例
 ```php

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kintone query builder php
 
-[![CircleCI](https://circleci.com/gh/toyokumo/kintone-query-builder-php.svg?style=svg)](https://circleci.com/gh/toyokumo/kintone-query-builder-php)
+[![Build and Test](https://github.com/toyokumo/kintone-query-builder-php/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/toyokumo/kintone-query-builder-php/actions/workflows/build-and-test.yml)
 
 [![PHP Version](https://img.shields.io/badge/php-7.2-pink.svg?style=flat-square)]()
 [![Latest Stable Version](https://poser.pugx.org/toyokumo/kintone-query-builder/v/stable)](https://packagist.org/packages/toyokumo/kintone-query-builder)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Query builder for [Kintone REST API](https://developer.kintone.io/hc/en-us/artic
 ## usage
 ### installation
 ```
-composer require toyokumo/kintone-query-builder:v1.0.0
-composer install
+composer require toyokumo/kintone-query-builder
 ```
 ### basic
 ```php


### PR DESCRIPTION
- https://github.com/toyokumo/kintone-query-builder-php/commit/fa01c014623ea0d85d444ac41ed5a1a5452d9f07
  - READMEの自動テスト結果バッジをCircle CIからGitHub Actionsのものに変更
- https://github.com/toyokumo/kintone-query-builder-php/commit/6a34e8f5a9bdc0636a30ab6b7a460bc91de2c5f5
  - READMEのinstallationセクションから、インストール時のバージョン指定を削除